### PR TITLE
не работает quit

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -22,7 +22,7 @@ fun main() {
         try {
             val func = taskActions[Actions.values()[action - 1]]
             func?.call(repository)
-        } catch (e: Exception) {
+        } catch (e: ArrayIndexOutOfBoundsException) {
             //just skip
         }
     }

--- a/src/main/kotlin/menu/Actions.kt
+++ b/src/main/kotlin/menu/Actions.kt
@@ -41,7 +41,7 @@ fun uncomplete(repository: TasksRepository) {
     repository.uncompleteTask(id)
 }
 
-fun quit() {
+fun quit(repository: TasksRepository) {
     exitProcess(0)
 }
 


### PR DESCRIPTION
Не выборе 7 из меню (QUIT) не отрабатывает вызов функции по причине несоответствия сигнатуры. Если убрать catch блок - получим `Exception in thread "main" java.lang.IllegalArgumentException: Callable expects 0 arguments, but 1 were provided.`

Можно поправить через унификацию функций - добавить параметр TasksRepository в функцию quit taskAction'а QUIT. И можно до кучи сузить отлавливаемые исключения до ArrayIndexOutOfBoundsException на случай неверного ввода